### PR TITLE
fix: add obscureSymbol single-character validation and align README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ void main() async {
   // Custom replacement
   final custom = SafeTextFilter.filterText(
     text: "What the f@ck!",
-    strategy: const MaskStrategy.custom(replacement: '[redacted]'),
+    strategy: const MaskStrategy.custom(replacement: '[censored]'),
   );
-  print(custom); // "What the [redacted]!"
+  print(custom); // "What the [censored]!"
 
   // Check for bad words
   final hasBad = await SafeTextFilter.containsBadWord(text: "Some bad input");
@@ -201,6 +201,8 @@ String custom = SafeTextFilter.filterText(
 | Full | `MaskStrategy.full(obscureSymbol: '*')` | `badass` → `******` | Replaces every character with the obscure symbol. |
 | Partial | `MaskStrategy.partial(obscureSymbol: '*')` | `damn` → `d**n`, `ass` → `a**` | Keeps first character visible. For 4+ letter words, also keeps the last character. |
 | Custom | `MaskStrategy.custom(replacement: '[censored]')` | `badass` → `[censored]` | Replaces the entire word with a fixed string. |
+
+> **Note:** `obscureSymbol` must be exactly one character. This is enforced via `assert` in debug mode — a multi-character string will trigger an `AssertionError` during development.
 
 ---
 

--- a/lib/src/models/mask_strategy.dart
+++ b/lib/src/models/mask_strategy.dart
@@ -4,6 +4,11 @@ const kDefaultObscureSymbol = '*';
 /// The default replacement string used by [CustomMask] when no custom value is provided.
 const kDefaultReplacement = '[censored]';
 
+/// {@template obscure_symbol_constraint}
+/// [obscureSymbol] must be exactly one character (e.g. `'*'`, `'#'`, `'X'`),
+/// defaults to [kDefaultObscureSymbol].
+/// {@endtemplate}
+///
 /// Controls how detected profanity is masked in filtered text.
 ///
 /// Three strategies are available:
@@ -16,12 +21,16 @@ sealed class MaskStrategy {
 
   /// Replaces every character with [obscureSymbol].
   ///
+  /// {@macro obscure_symbol_constraint}
+  ///
   /// Example: `"badass"` → `"******"`
   const factory MaskStrategy.full({String obscureSymbol}) = FullMask;
 
   /// Keeps the first character visible and masks the rest. For words with
   /// 4 or more characters, also keeps the last character visible.
   /// Single-character matches are fully replaced with the obscure symbol.
+  ///
+  /// {@macro obscure_symbol_constraint}
   ///
   /// Examples:
   /// - `"damn"` → `"d**n"` (4+ letters: first & last visible)
@@ -37,21 +46,31 @@ sealed class MaskStrategy {
   const factory MaskStrategy.custom({String replacement}) = CustomMask;
 }
 
-/// Masks every character of the matched word with [obscureSymbol].
-class FullMask extends MaskStrategy {
-  /// The character used to replace each letter of the matched word.
+/// Base class for strategies that mask with a single [obscureSymbol] character.
+///
+/// {@macro obscure_symbol_constraint}
+sealed class ObscureSymbolStrategy extends MaskStrategy {
+  /// {@macro obscure_symbol_constraint}
   final String obscureSymbol;
 
-  const FullMask({this.obscureSymbol = kDefaultObscureSymbol});
+  const ObscureSymbolStrategy({this.obscureSymbol = kDefaultObscureSymbol})
+      : assert(obscureSymbol.length == 1,
+            'obscureSymbol must be a single character');
+}
+
+/// Masks every character of the matched word with [obscureSymbol].
+///
+/// {@macro obscure_symbol_constraint}
+class FullMask extends ObscureSymbolStrategy {
+  const FullMask({super.obscureSymbol});
 }
 
 /// Partially masks the matched word, keeping the first character visible.
 /// For words with 4+ characters, also keeps the last character visible.
-class PartialMask extends MaskStrategy {
-  /// The character used to replace masked letters.
-  final String obscureSymbol;
-
-  const PartialMask({this.obscureSymbol = kDefaultObscureSymbol});
+///
+/// {@macro obscure_symbol_constraint}
+class PartialMask extends ObscureSymbolStrategy {
+  const PartialMask({super.obscureSymbol});
 }
 
 /// Replaces the entire matched word with a fixed [replacement] string.

--- a/test/profanity_filter_test.dart
+++ b/test/profanity_filter_test.dart
@@ -189,6 +189,20 @@ void main() {
           "Hello $replacement");
     });
 
+    test('FullMask throws AssertionError for multi-character obscureSymbol',
+        () {
+      expect(
+          () => MaskStrategy.full(obscureSymbol: '##'),
+          throwsA(isA<AssertionError>()));
+    });
+
+    test('PartialMask throws AssertionError for multi-character obscureSymbol',
+        () {
+      expect(
+          () => MaskStrategy.partial(obscureSymbol: '##'),
+          throwsA(isA<AssertionError>()));
+    });
+
     test('backward compat: fullMode: true still produces full masking', () {
       // ignore: deprecated_member_use
       expect(

--- a/test/profanity_filter_test.dart
+++ b/test/profanity_filter_test.dart
@@ -191,15 +191,13 @@ void main() {
 
     test('FullMask throws AssertionError for multi-character obscureSymbol',
         () {
-      expect(
-          () => MaskStrategy.full(obscureSymbol: '##'),
+      expect(() => MaskStrategy.full(obscureSymbol: '##'),
           throwsA(isA<AssertionError>()));
     });
 
     test('PartialMask throws AssertionError for multi-character obscureSymbol',
         () {
-      expect(
-          () => MaskStrategy.partial(obscureSymbol: '##'),
+      expect(() => MaskStrategy.partial(obscureSymbol: '##'),
           throwsA(isA<AssertionError>()));
     });
 


### PR DESCRIPTION
## Summary

- Extracts `ObscureSymbolStrategy` base class to centralize the `obscureSymbol` field and its single-character `assert` — shared by both `FullMask` and `PartialMask`
- Uses dartdoc `{@template}`/`{@macro}` to document the constraint without repetition
- Adds tests confirming `AssertionError` for multi-character `obscureSymbol`
- Aligns README custom replacement examples to consistently use `[censored]`
- Adds a note in the README about the single-character assert

## Changes

```mermaid
classDiagram
    MaskStrategy <|-- ObscureSymbolStrategy
    MaskStrategy <|-- CustomMask
    ObscureSymbolStrategy <|-- FullMask
    ObscureSymbolStrategy <|-- PartialMask

    class MaskStrategy {
        <<sealed>>
    }
    class ObscureSymbolStrategy {
        <<sealed>>
        +String obscureSymbol
        assert(obscureSymbol.length == 1)
    }
    class FullMask
    class PartialMask
    class CustomMask {
        +String replacement
    }
```

## Test plan

- [x] 25/25 tests passing
- [x] `MaskStrategy.full(obscureSymbol: '##')` throws `AssertionError`
- [x] `MaskStrategy.partial(obscureSymbol: '##')` throws `AssertionError`
- [x] All existing strategy tests unaffected
- [x] README examples consistent

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Masking strategy now enforces that obscure symbols must be exactly one character in length. Multi-character values will trigger an assertion error during development, helping catch constraint violations early.

* **Documentation**
  * Updated masking strategy examples to use consistent placeholder values and added explicit documentation clarifying the single-character requirement for obscure symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->