### PR TITLE
fix: emoji and supplementary Unicode characters match failure in AhoCorasick

### DIFF
--- a/lib/src/aho_corasick.dart
+++ b/lib/src/aho_corasick.dart
@@ -56,7 +56,7 @@ class AhoCorasick {
     final matches = <int, List<String>>{};
     TrieNode? current = _root;
     final textLower = text.toLowerCase();
-    final units = textLower.codeUnits;
+    final units = textLower.runes.toList();
 
     for (int i = 0; i < units.length; i++) {
       final rune = units[i];


### PR DESCRIPTION
Fixes #31

Changed `AhoCorasick.search` to use `.runes` instead of `.codeUnits` to match the behavior of `addWord`. This ensures that emoji and other supplementary Unicode characters (outside BMP) are correctly matched during search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced search functionality to properly handle Unicode characters and international text, ensuring accurate results across different character sets and scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->