### PR TITLE
fix: use runes instead of codeUnits in AhoCorasick search

### DIFF
--- a/lib/src/aho_corasick.dart
+++ b/lib/src/aho_corasick.dart
@@ -56,7 +56,7 @@ class AhoCorasick {
     final matches = <int, List<String>>{};
     TrieNode? current = _root;
     final textLower = text.toLowerCase();
-    final units = textLower.codeUnits;
+    final units = textLower.runes.toList();
 
     for (int i = 0; i < units.length; i++) {
       final rune = units[i];


### PR DESCRIPTION
The AhoCorasick search was using  while the trie was built using . This caused matching to fail for emoji and other characters outside the Basic Multilingual Plane (BMP). This PR fixes the issue by using  in the search loop as well.

Closes #31